### PR TITLE
[ISSUE #4] Add docker build manual and fix dockerhub push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,15 +26,17 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
-          tags: eventmesh/eventmesh-dashboard:latest
-          file: ./docker/Dockerfile
-          context: ./
+          tags: apache/eventmesh-dashboard:latest
+          file: docker/Dockerfile
+          context: .

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ You can start editing the page by modifying `pages/index.tsx`. The page auto-upd
 
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
 
+## Getting Started with Docker
+
+Pull the image and run the container by following commands:
+
+```
+docker pull apache/eventmesh-dashboard:latest
+```
+
+```
+docker run -d --name eventmesh-dashboard -p 8080:80 -t apache/eventmesh-dashboard:latest
+```
+
+Open [http://localhost:8080](http://localhost:8080) in your browser to see the result.
+
+You can also build a mirror of your own by executing the following command in the root of your git repository:
+
+```
+docker build -t <your-name>/eventmesh-dashboard:latest -f docker/Dockerfile .
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
1. Add docker build manual
2. Fix Apache DockerHub push

![image](https://github.com/apache/eventmesh-dashboard/assets/41445332/8a533477-5300-4c71-8c50-fd6145adfae2)

![image](https://github.com/apache/eventmesh-dashboard/assets/41445332/beb12b06-8cb1-42e1-80da-01a5873fe8ee)

![image](https://github.com/apache/eventmesh-dashboard/assets/41445332/c514a18b-c759-4702-80fc-e7584d2be7d9)

![image](https://github.com/apache/eventmesh-dashboard/assets/41445332/dd68b5a3-79c6-461f-80de-ab94046b4e09)
