### PR TITLE
[ISSUE #6] Fix DockerHub PASSWORD obtaining

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,15 +26,17 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
-          tags: eventmesh/eventmesh-dashboard:latest
-          file: ./docker/Dockerfile
-          context: ./
+          tags: apache/eventmesh-dashboard:latest
+          file: docker/Dockerfile
+          context: .

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ You can start editing the page by modifying `pages/index.tsx`. The page auto-upd
 
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
 
+## Getting Started with Docker
+
+Pull the image and run the container by following commands:
+
+```
+docker pull apache/eventmesh-dashboard:latest
+```
+
+```
+docker run -d --name eventmesh-dashboard -p 8080:80 -t apache/eventmesh-dashboard:latest
+```
+
+Open [http://localhost:8080](http://localhost:8080) in your browser to see the result.
+
+You can also build a mirror of your own by executing the following command in the root of your git repository:
+
+```
+docker build -t <your-name>/eventmesh-dashboard:latest -f docker/Dockerfile .
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
The DOCKERHUB_TOKEN is given instead of DOCKERHUB_PASSWORD in build-push-action examples.

It is possible that the apache repository is configured with only DOCKERHUB_TOKEN and not DOCKERHUB_PASSWORD.

![image](https://github.com/apache/eventmesh-dashboard/assets/41445332/57095d9e-ffa7-4bda-bf30-be5c2e7fc55f)
