### PR TITLE
[ISSUE #32] Set up GitHub MySQL workflow to support unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,19 +36,22 @@ jobs:
         language: ['java']
     runs-on: ${{ matrix.os }}
 
-    env:
-      DB_DATABASE: EVENTMESH_DASHBOARD
-      DB_USER: root
-      DB_PASSWORD: root
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          # The MySQL docker container requires these environment variables to be set, so we can create and migrate the test database.
+          MYSQL_DATABASE: EVENTMESH_DASHBOARD
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
+          - 3306:3306
+        # Set health checks to wait until MySQL has started
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Set up MySQL
-        run: |
-          sudo systemctl start mysql.service
-          mysql -e "CREATE DATABASE IF NOT EXISTS $DB_DATABASE;" -u$DB_USER -p$DB_PASSWORD
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      DB_DATABASE: eventmesh-dashboard
+      DB_DATABASE: EVENTMESH_DASHBOARD
       DB_USER: root
       DB_PASSWORD: root
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,23 +36,19 @@ jobs:
         language: ['java']
     runs-on: ${{ matrix.os }}
 
-    services:
-      mysql:
-        image: mysql:8
-        env:
-          # The MySQL docker container requires these environment variables to be set
-          # so we can create and migrate the test database.
-          MYSQL_DATABASE: eventmesh-dashboard
-          MYSQL_ROOT_PASSWORD: password
-        ports:
-          # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
-          - 3306:3306
-        # Set health checks to wait until MySQL has started
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    env:
+      DB_DATABASE: eventmesh-dashboard
+      DB_USER: root
+      DB_PASSWORD: password
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up MySQL
+        run: |
+          sudo systemctl start mysql.service
+          mysql -e "CREATE DATABASE IF NOT EXISTS $DB_DATABASE;" -u$DB_USER -p$DB_PASSWORD
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,20 @@ jobs:
         language: ['java']
     runs-on: ${{ matrix.os }}
 
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          # The MySQL docker container requires these environment variables to be set
+          # so we can create and migrate the test database.
+          MYSQL_DATABASE: eventmesh-dashboard
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
+          - 3306:3306
+        # Set health checks to wait until MySQL has started
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       DB_DATABASE: eventmesh-dashboard
       DB_USER: root
-      DB_PASSWORD: password
+      DB_PASSWORD: root
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fixes #32.

There are two ways to set up MySQL in GitHub workflow. One is setting up a docker container and another is starting the bundled MySQL service of GitHub's ubuntu image.

However, there is no MySQL bundled in GitHub's macos image, so the former way will be a more universal setup.